### PR TITLE
Lateral movement major bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ DEM/geotiff_test.py
 *.gif
 *.jpg
 *.tif
+*.gif
 *.dat
 *.nc
 *.pkl
@@ -24,3 +25,4 @@ validation/*.png
 validation/AntarcticLakes/
 src/model_setup.py
 examples/*/output/
+*.ipynb

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,7 +5,7 @@ Welcome to MONARCHS's documentation!
 
 **MONARCHS** is a model of Antarctic ice shelf stability and hydrology written in Python.
 Please see the :doc:`installation` section for information on how to obtain MONARCHS,
-and the and :doc:`quickstart` section for a quickstart guide on how to set it up and run it.
+and the :doc:`quickstart` section for a quickstart guide on how to set it up and run it.
 
 
 .. note::

--- a/docs/source/making_changes.rst
+++ b/docs/source/making_changes.rst
@@ -37,7 +37,7 @@ Any changes that require amendments to ``model_setup.py``
 should have suitable documentation added to ``docs/source/model_setup_reference.rst``.
 
 Advanced users
-==============
+------------------------------------
 Adding functions with Numba support
 ***********************************
 

--- a/examples/10x10_gaussian_threelake/model_setup.py
+++ b/examples/10x10_gaussian_threelake/model_setup.py
@@ -58,11 +58,12 @@ Met data parameters
 met_data = {}
 timesteps_warm = 800
 timesteps_cold = 1720
-met_data["LW_surf"] = np.append(timesteps_warm * np.ones(timesteps_warm), 100 * np.ones(timesteps_cold))  # Incoming longwave radiation. [W m^-2].
-met_data["SW_surf"] = np.append(timesteps_warm * np.ones(timesteps_warm), 100 * np.ones(timesteps_cold))  # Incoming shortwave (solar) radiation. [W m^-2].
-met_data["temperature"] = np.append(267 * np.ones(timesteps_warm), 250 * np.ones(timesteps_cold))  # Surface-layer air temperature. [K].
-met_data["pressure"] = 1000 * np.ones(num_days * t_steps_per_day)  # Surface-layer air pressure. [hPa].
+met_data["LW_surf"] = np.append(800 * np.ones(timesteps_warm), 100 * np.ones(timesteps_cold))  # Incoming longwave radiation. [W m^-2].
+met_data["SW_surf"] = np.append(800 * np.ones(timesteps_warm), 100 * np.ones(timesteps_cold))  # Incoming shortwave (solar) radiation. [W m^-2].
 met_data["dew_point_temperature"] = np.append(265 * np.ones(timesteps_warm), 240 * np.ones(timesteps_cold))  # Dew-point temperature. [K].
+met_data["temperature"] = np.append(267 * np.ones(timesteps_warm), 250 * np.ones(timesteps_cold))  # Surface-layer air temperature. [K].
+
+met_data["pressure"] = 1000 * np.ones(num_days * t_steps_per_day)  # Surface-layer air pressure. [hPa].
 met_data["wind"] = 5 * np.ones(num_days * t_steps_per_day)  # Wind speed. [m s^-1].
 met_data["snowfall"] = 0 * np.ones(num_days * t_steps_per_day)  # Snowfall rate. [m s^-1].
 met_data["snow_dens"] = 300 * np.ones(num_days * t_steps_per_day)  # Snow density. [kg m^-3].
@@ -94,18 +95,18 @@ dump_data = True
 dump_filepath = (
     "output/gaussian_threelake_example_dump.nc"  # Filename of our previously dumped state
 )
-reload_from_dump = False  # Flag to determine whether to reload the state or not
+reload_from_dump = False # Flag to determine whether to reload the state or not
 
 """
 Computing and numerical parameters
 """
 use_numba = False  # Use Numba-optimised version (faster, but harder to debug)
-parallel = False  # run in parallel or serial. Parallel is of course much faster for large model grids, but you may
+parallel = True  # run in parallel or serial. Parallel is of course much faster for large model grids, but you may
 # wish to run serial if doing single-column calculations.
 
 spinup = False  # Try and force the firn column heat equation to converge at the start of the run?
 verbose_logging = False  # if True, output logs every "timestep" (hour). # Otherwise, log only every "iteration" (day).
-cores = "all"  # number of processing cores to use. 'all' or False will tell MONARCHS to use all available cores.
+cores = 10  # number of processing cores to use. 'all' or False will tell MONARCHS to use all available cores.
 
 """
 Toggles to turn on or off various parts of the model. These should only be changed for testing purposes. 
@@ -114,9 +115,12 @@ All of these default to True.
 catchment_outflow = False  # Determines if water on the edge of the catchment area will
 # preferentially stay within the model grid,
 # or flow out of the catchment area (resulting in us 'losing' water)
-flow_into_land = True # As above, but for flowing into invalid cells in addition to the model edge boundaries.
+flow_into_land = False # As above, but for flowing into invalid cells in addition to the model edge boundaries.
+
+# Just for this specific case - assert that the DEM is symmetric
+import numpy.testing as npt
+npt.assert_array_equal(firn_depth, firn_depth[::-1, ::-1])
 
 if __name__ == '__main__':
     from monarchs.core.driver import monarchs
-
     grid = monarchs()

--- a/examples/model_setup_template.py
+++ b/examples/model_setup_template.py
@@ -15,11 +15,11 @@ Spatial parameters
 
     row_amount : int
         Number of rows (i.e. `y`-points) in your model grid, looking from top-down. 
-        MONARCHS indexes the model grid via `grid[col][row]`, i.e. the `y`-coordinate is the second index.
+        MONARCHS indexes the model grid via `grid[row][col]`, i.e. the `x`-coordinate is the second index.
 
     col_amount : int
         Number of columns (i.e. `x`-points) in your model grid, looking from top-down.
-        MONARCHS indexes the model grid via `grid[col][row]`, i.e. the `x`-coordinate is the first index.
+        MONARCHS indexes the model grid via `grid[row][col]`, i.e. the `y`-coordinate is the first index.
     
     lat_grid_size : float, or str
         Size of each grid cell in m. This is used to determine how much water can flow during the lateral

--- a/scripts/plot_gif.py
+++ b/scripts/plot_gif.py
@@ -1,0 +1,25 @@
+from netCDF4 import Dataset
+from matplotlib import pyplot as plt
+import numpy.ma as ma
+import matplotlib
+from matplotlib.animation import ArtistAnimation
+matplotlib.use('TkAgg')
+dumppath = '../examples/10x10_gaussian_threelake/output/gaussian_threelake_example_dump_df.nc'
+diagpath = '../examples/10x10_gaussian_threelake/output/gaussian_threelake_example_output_df.nc'
+
+# Load in the data - just focusing on lake depth from the diagnostics file
+
+diagnostic_data = Dataset(diagpath)
+
+lake_depth = diagnostic_data.variables['lake_depth']
+
+diagnostic_data.close()
+# Plot the lake depth - we want to generate an ArtistAnimation to do this so we can create a gif over time
+fig, ax = plt.subplots()
+ims = []
+for i in range(len(lake_depth)):
+    im = ax.imshow(lake_depth[i])
+    ims.append([im])
+
+ani = ArtistAnimation(fig, ims, interval=500, blit=True, repeat_delay=1000)
+ani.save('lake_depth.gif', writer='imagemagick')

--- a/scripts/plot_output.py
+++ b/scripts/plot_output.py
@@ -9,7 +9,8 @@ visually how it has changed over time.
 from netCDF4 import Dataset
 from matplotlib import pyplot as plt
 import numpy.ma as ma
-
+import matplotlib
+matplotlib.use('TkAgg')
 dumppath = '../examples/10x10_gaussian_threelake/output/gaussian_threelake_example_dump.nc'
 diagpath = '../examples/10x10_gaussian_threelake/output/gaussian_threelake_example_output.nc'
 
@@ -70,3 +71,5 @@ plt.imshow(diff, cmap='coolwarm', norm=TwoSlopeNorm(vmin=-3, vcenter=0, vmax=3))
 plt.colorbar()
 plt.title('Firn depth difference (m)')
 
+flowdata.close()
+t0data.close()

--- a/src/monarchs/DEM/create_DEM_GaussianTestCase.py
+++ b/src/monarchs/DEM/create_DEM_GaussianTestCase.py
@@ -35,16 +35,12 @@ def export_gaussian_DEM(num_points=20, diagnostic_plots=False):
         )
         return 1 - height
 
-    x = y = np.linspace(-1, 1, 50)
+    x = y = np.linspace(-1, 1, 10)
     x1, y1 = np.meshgrid(x, y)
 
     heights = Gaussian(x1, y1)
-    heights[6:9, 6:9] = 0.7
-    heights[41:44, 41:44] = 0.7
-    heights[5:10, 7:8] = 0.7
-    heights[7:8, 5:10] = 0.7
-    heights[40:45, 42:43] = 0.7
-    heights[42:43, 40:45] = 0.7
+    heights[1, 1] = 0.5
+    heights[8, 8] = 0.5
     # Get the scale factor from the number of points originally generated and the number of points requested
     scale = len(heights) / num_points
 
@@ -63,6 +59,9 @@ def export_gaussian_DEM(num_points=20, diagnostic_plots=False):
 
     interpolated_heights = interpolate_DEM(heights, scale)
     # Scale of 2 is ok here, 4 looses the 2 smaller lakes (but they could be made deeper if needed?)
+
+    # Force DEM to be completely symmetric
+    interpolated_heights = (interpolated_heights + interpolated_heights[::-1,::-1]) / 2
 
     if diagnostic_plots:
         fig = plt.figure(figsize=(4, 2))

--- a/src/monarchs/core/driver.py
+++ b/src/monarchs/core/driver.py
@@ -396,6 +396,7 @@ def main(model_setup, grid):
 
     # Main model loop here.
     for day in time_loop:
+
         dt = 3600  # In seconds timestep for each iteration of heat eqn solver
         print("\n*******************************************\n")
         print(f"Start of model day {day + 1}\n")
@@ -450,6 +451,7 @@ def main(model_setup, grid):
                 outfile = open(model_setup.dump_filepath, 'wb')
                 pickle.dump(grid, outfile)
                 outfile.close()
+
         # Handle the lateral movement, but only if the toggle is set to True.
         if model_setup.lateral_movement_toggle:
             print("Moving water laterally...")

--- a/src/monarchs/core/loop_over_grid.py
+++ b/src/monarchs/core/loop_over_grid.py
@@ -120,7 +120,7 @@ def loop_over_grid(
                     iceshelf.append(result)
             # COMM.Barrier()
         else:
-            with Pool(nodes=ncores) as p:
+            with Pool(nodes=ncores, maxtasksperchild=1) as p:
                 # we want to get out our IceShelf and our Logger grids, so get out an array res and index it
                 # to get these
                 res = p.map(

--- a/src/monarchs/core/utils.py
+++ b/src/monarchs/core/utils.py
@@ -46,13 +46,13 @@ def get_2d_grid(grid, attr, index=False):
     # if no index specified, get surface values
     if not index:
         index = 0
-    var = [None] * len(grid[0])
-    for row in range(len(grid[0])):
-        var[row] = [None] * len(grid)
-        for col in range(len(grid)):
+    var = [None] * len(grid)
+    for row in range(len(grid)):
+        var[row] = [None] * len(grid[0])
+        for col in range(len(grid[0])):
             var[row][col] = getattr(
-                grid[col][row], attr
-            )  # need to reverse order of row and col to not transpose
+                grid[row][col], attr
+            )
 
     # get all values
     if index == "all":

--- a/src/monarchs/physics/lateral_functions.py
+++ b/src/monarchs/physics/lateral_functions.py
@@ -25,8 +25,7 @@ def update_water_level(cell):
     -------
 
     """
-    # cell.water is only used for the lateral movement. So we first need to update it based on Lfrac,
-    # which is used in the rest of MONARCHS.
+
     if not cell.valid_cell:
         cell.water_level = 999
         return
@@ -47,7 +46,9 @@ def update_water_level(cell):
         # Otherwise, water is free to percolate all the way to the bottom, so it doesn't move laterally from here.
         else:
             cell.water_level = 0
-        # Update the water content based on the Lfrac of the firn
+
+        # cell.water is only used for the lateral movement. So we first need to update it based on Lfrac,
+        # which is used in the rest of MONARCHS.
         cell.water = cell.Lfrac * (cell.firn_depth / cell.vert_grid)
 
     # Add lake depth into water for the purposes of moving it around if a lake is present.
@@ -69,49 +70,52 @@ def update_water_level(cell):
 
 
 def get_neighbour_water_levels(cell, grid, col, row, max_grid_col, max_grid_row):
-    # if not on left edge of domain - init W, possibly NW/NW
     neighbours = {}
 
+    # if not on bottom edge of domain - init N, possibly NE/NW
+
     if row > 0:
-        neighbours['W'] = cell.water_level - grid[col][row - 1].water_level
+        # north neighbour = -1 in row index (i.e. when selecting rows, previous row
+        # is the cell directly above)
+        neighbours['N'] = cell.water_level - grid[row - 1][col].water_level
 
         if col < max_grid_col - 1:  # if not at right edge - init NE
-            neighbours['SW'] = cell.water_level - grid[col + 1][row - 1].water_level
+            neighbours['NE'] = cell.water_level - grid[row - 1][col + 1].water_level
         if col > 0:  # if not at left edge - init NW
-            neighbours['NW'] = cell.water_level - grid[col - 1][row - 1].water_level
-    else:  # if at left edge - W/NW/SW all False
-        neighbours['W'] = -999
+            neighbours['NW'] = cell.water_level - grid[row - 1][col - 1].water_level
+    else:  # if at top edge - N/NW/NE all False
+        neighbours['N'] = -999
+        neighbours['NE'] = -999
         neighbours['NW'] = -999
-        neighbours['SW'] = -999
 
-    # if not on right edge of domain - init E, possibly SE/NE
+    # if not on bottom edge of domain - init E, possibly SE/NE
     if row < max_grid_row - 1:
-        neighbours['E'] = cell.water_level - grid[col][row + 1].water_level
+        neighbours['S'] = cell.water_level - grid[row + 1][col].water_level
 
         if col < max_grid_col - 1:  # if not at bottom - init SE
-            neighbours['SE'] = cell.water_level - grid[col + 1][row + 1].water_level
+            neighbours['SE'] = cell.water_level - grid[row + 1][col + 1].water_level
         if col > 0:  # if not at top - init NE
-            neighbours['NE'] = cell.water_level - grid[col - 1][row + 1].water_level
+            neighbours['SW'] = cell.water_level - grid[row + 1][col - 1].water_level
 
-    else:  # if at left edge - E/NE/SE all False
-        neighbours['E'] = -999
-        neighbours['SE'] = -999
-        neighbours['NE'] = -999
-
-    if col > 0:  # if not at top edge - initialise north neighbour
-        neighbours['N'] = cell.water_level - grid[col - 1][row].water_level
-    else:
-        neighbours['N'] = -999
-        neighbours['NE']= -999
-        neighbours['NW'] = -999
-
-    # if not at bottom edge - initialise south neighbour
-    if col < max_grid_col - 1:
-        neighbours['S'] = cell.water_level - grid[col + 1][row].water_level
-    else:
+    else:  # if at bottom edge - S/SW/SE all False
         neighbours['S'] = -999
         neighbours['SE'] = -999
         neighbours['SW'] = -999
+
+    if col > 0:  # if not at left edge - initialise W neighbour
+        neighbours['W'] = cell.water_level - grid[row][col - 1].water_level
+    else:
+        neighbours['W'] = -999
+        neighbours['SW']= -999
+        neighbours['NW'] = -999
+
+    # if not at right edge - initialise east neighbour(s)
+    if col < max_grid_col - 1:
+        neighbours['E'] = cell.water_level - grid[row][col + 1].water_level
+    else:
+        neighbours['E'] = -999
+        neighbours['SE'] = -999
+        neighbours['NE'] = -999
     return neighbours
 
 
@@ -147,13 +151,13 @@ def find_biggest_neighbour(
 
     all_neighbours = {
         "1": [-1, -1],  # NW
-        "2": [-1, 0],  # N
-        "3": [-1, 1],  # NE
-        "4": [0, -1],  # W
-        "5": [0, 1],  # E
-        "6": [1, -1],  # SW
-        "7": [1, 0],  # S
-        "8": [1, 1],  # SE
+        "2": [-1, 0],  # W
+        "3": [-1, 1],  # SW
+        "4": [0, -1],  # S
+        "5": [0, 1],  # N
+        "6": [1, -1],  # SE
+        "7": [1, 0],  # E
+        "8": [1, 1],  # NE
     }
     """
 
@@ -176,6 +180,7 @@ def find_biggest_neighbour(
             for j in range(-1, 2, 1):
                 try:
                     code = ''
+
                     if i == -1:
                         code += 'N'
                     elif i == 1:
@@ -185,7 +190,7 @@ def find_biggest_neighbour(
                     elif j == 1:
                         code += 'E'
 
-                    neighbour_cell = grid[col + i][row + j]
+                    neighbour_cell = grid[row + i][col + j]
                     # If the water level is a local minimum, then we want to flow water into the land.
                     if max(neighbours.values()) <= 0:
                         if not neighbour_cell.valid_cell:
@@ -211,7 +216,18 @@ def find_biggest_neighbour(
     # max_list = [
     #     idx for idx, val in enumerate(neighbour_list) if (val == biggest_height_difference and val > 0)
     # ]
+
     max_list = [k for k, v in neighbours.items() if v == biggest_height_difference]
+
+    # A fix for the symmetric test case. What was happening was that there were tiny rounding errors. This caused
+    # water to preferentially move one way over the other, which is bad for a symmetric case! This fixes the issue.
+    # Append any that are within a rounding error
+    # (i.e. if the difference is 0.0000000001, then we want to include it)
+    for k, v in neighbours.items():
+        if biggest_height_difference - v < 1E-8:
+            if k not in max_list:
+                max_list.append(k)
+
 
     return biggest_height_difference, max_list
 
@@ -253,7 +269,7 @@ def water_fraction(cell, m, timestep, direction):
     eta = 1.787 * 10 ** -3  # viscosity(Pa/s)
     if cell.lake:
         return 1  # if in a lake all water moves
-
+    cell.rho = cell.Sfrac * cell.rho_ice + cell.Lfrac * cell.rho_water
     cell_density = cell.rho
 
     u = Big_pi / eta * m / cell_size * cell_density * -9.8  # flow speed (m/s)
@@ -288,8 +304,8 @@ def calc_available_water(cell, water_frac, split, neighbour_cell=False, outflow=
 
     """
     # central cell - (split * water_to_move) = outside cell + water_to_move
-    # > water_to_move * split + 1 = central_cell - outside_cell
-    # > water_to_move = central_cell - outside_cell / (split + 1)
+    # > water_to_move * split = central_cell - outside_cell
+    # > water_to_move = central_cell - outside_cell / (split)
     # only the case if outside cells are equal so far - maybe change in future
     # We need to move enough water for the water levels to equalise.
     # If lake depth < difference between water levels, then all needs to move.
@@ -304,11 +320,11 @@ def calc_available_water(cell, water_frac, split, neighbour_cell=False, outflow=
                 (cell.water_level - neighbour_cell.water_level) / (split + 1)
         )
         # Ensure we have enough water to fill our "quota" - else everything goes but no more.
-        # multiply by split + 1 since we want the total water that can move.
+        # multiply by split since we want the total water that can move.
         # water frac is always 1 if the central cell is a lake
         # so doesn't pose a problem
-        if cell.lake_depth < water_to_move * (split):
-            water_to_move = cell.lake_depth / (split)
+        if cell.lake_depth < water_to_move * (split + 1):
+            water_to_move = cell.lake_depth / (split + 1)
         return water_to_move
 
     elif cell.ice_lens and not cell.lake:
@@ -339,15 +355,14 @@ def calc_available_water(cell, water_frac, split, neighbour_cell=False, outflow=
 
         water_to_move = (
                 water_frac[move_from_index]
-                * ((cell.water_level - neighbour_cell.water_level) / 2)
+                * (cell.water_level - neighbour_cell.water_level)
                 / (split + 1)
         )
 
         # If saturated firn doesn't hold enough water to fill the "quota", then all of it moves but no more
         # +1 so we include the one where we move from
-        if (
-                np.sum(cell.water[: move_from_index + 1]) / (split + 1) < water_to_move
-        ):  # i.e. if more water is allowed to move than we have in the cell
+        if np.sum(cell.water[: move_from_index + 1]) / (split + 1) < water_to_move:
+            # i.e. if more water is allowed to move than we have in the cell
             water_to_move = np.sum(cell.water[: move_from_index + 1]) / (split + 1)
         return (
             water_to_move,
@@ -356,7 +371,7 @@ def calc_available_water(cell, water_frac, split, neighbour_cell=False, outflow=
             top_saturation_level,
         )
     else:
-        return 0  # water should not be able to move from this cell
+        raise ValueError('Water should not be able to flow from this cell')  # water should not be able to move from this cell
 
 
 def calc_catchment_outflow(cell, temporary_cell, water_frac, split):
@@ -413,7 +428,7 @@ def move_to_neighbours(
     """
     Moves water from the central cell (grid[i][j]) to the neighbours with the lowest water level.
     The specific neighbour is associated with an index [i + m][j + n] with m, n = [-1, 0, 1].
-    e.g. SW neighbour is associated with the m = -1, n = +1.
+    e.g. SW neighbour is associated with the m = +1, n = -1.
     How the movement is handled is dependent on the features of the cell and its neighbour.
     Called in <move_water>.
 
@@ -444,16 +459,17 @@ def move_to_neighbours(
         This can occur if the lake depth goes below 0, or if there is water to move in a grid cell where water
         should not be able to move from (i.e. no lake or ice lens)
     """
-
+    # recall that the "column" index is our *x* coordinate, not y, and we index
+    # by [row, col]
     all_neighbours = {
-        "NW": [-1, -1],  # NW
-        "N": [-1, 0],  # N
-        "NE": [-1, 1],  # NE
-        "W": [0, -1],  # W
-        "E": [0, 1],  # E
-        "SW": [1, -1],  # SW
-        "S": [1, 0],  # S
-        "SE": [1, 1],  # SE
+        "NW": [-1, -1],
+        "N": [-1, 0],
+        "NE": [-1, 1],
+        "E": [0, 1],
+        "SE": [1, 1],
+        "S": [1, 0],
+        "SW": [1, -1],
+        "W": [0, -1],
     }
 
     # for each of the neighbours we wish to move water to, which depends on the difference
@@ -462,28 +478,28 @@ def move_to_neighbours(
         if neighbour in biggest_neighbours:
 
 
-            n_s_index = all_neighbours[neighbour][0]
-            w_e_index = all_neighbours[neighbour][1]
-            cell = grid[col][row]
-            temporary_cell = temp_grid[col][row]
+            n_s_index = all_neighbours[neighbour][0]  # i.e. row index
+            w_e_index = all_neighbours[neighbour][1]  # i.e. col index
+            cell = grid[row][col]
+            temporary_cell = temp_grid[row][col]
             water_frac = water_fraction(
                 cell, biggest_height_difference, timestep, neighbour
             )
             if cell.lid:
                 return 0
 
+            # Before actually moving water, we first need to find out how much water can actually move.
             # This try/except block happens in all non-lid cases, and determines how much water can move from the
             # central cell to the neighbour cell. If the neighbour cell is invalid, then we don't want to move water
             # (or maybe we do if flow_into_land is True).
             try:
-                if (
-                        col + n_s_index == -1 or row + w_e_index == -1
-                ):  # edge case handling - since Python handles "-1" as
+                if row + n_s_index == -1 or col + w_e_index == -1 or row + n_s_index >= len(grid) or col + w_e_index >= len(grid[0]):
+                    # edge case handling - since Python handles "-1" as
                     # a valid index this will impose periodic boundary conditions rather than raise an error, which
                     # is not the behaviour we want!
                     raise IndexError
-                neighbour_cell = grid[col + n_s_index][row + w_e_index]
-                temporary_neighbour = temp_grid[col + n_s_index][row + w_e_index]
+                neighbour_cell = grid[row + n_s_index][col + w_e_index]
+                temporary_neighbour = temp_grid[row + n_s_index][col + w_e_index]
                 # If cell is invalid, we aren't interested in flowing water
                 if not neighbour_cell.valid_cell and not flow_into_land:
                     continue
@@ -549,8 +565,9 @@ def move_to_neighbours(
                 temporary_cell.lake_depth -= water_to_move
 
                 # Fix floating-point errors before sanity checking
-                if 0 > temporary_cell.lake_depth > -0.001:
+                if 0 > temporary_cell.lake_depth > -0.000000000001:
                     temporary_cell.lake_depth = 0
+                    print('Fixed floating point error in lake depth')
 
                 if temporary_cell.lake_depth < 0:
                     print("After = ", temporary_cell.lake_depth)
@@ -581,10 +598,11 @@ def move_to_neighbours(
                     move_to_index = 0
                 # We now need to update the amount of water in the initial firn column.
                 # Water can only be deducted from the area above lowest_water_level.
-
                 for idx in range(top_saturation_level, move_from_index + 1):
                     # If more water in cell than we can move, then subtract that amount from the current cell
-                    if cell.water[idx] > water_to_move:
+
+                    # JE - added factor of split so water is evenly moved from the bottom
+                    if cell.water[idx] / (split + 1) > water_to_move:
                         temporary_cell.water[idx] -= water_to_move
                         if not neighbour_cell.lake:
                             temporary_neighbour.water[move_to_index] += water_to_move
@@ -592,16 +610,20 @@ def move_to_neighbours(
                         else:
                             temporary_neighbour.lake_depth += water_to_move
 
+
                         temporary_cell.saturation[idx] = 0
+                        water_to_move = 0
                     # Otherwise - remove all of it from that cell and go up one.
                     else:
-                        water_to_move -= cell.water[idx]
+                        temporary_cell.water[idx] -= cell.water[idx] / (split + 1)
+                        water_to_move -= cell.water[idx] / split
                         if not neighbour_cell.lake:
-                            temporary_neighbour.water[move_to_index] += cell.water[idx]
+                            temporary_neighbour.water[move_to_index] += cell.water[idx] / (split + 1)
                             temporary_neighbour.meltflag[move_to_index] = 1
                         else:
-                            temporary_neighbour.lake_depth += cell.water[idx]
-                        temporary_cell.water[idx] = 0
+                            temporary_neighbour.lake_depth += cell.water[idx] / (split + 1)
+                        temporary_cell.saturation[idx] = 0
+
 
             else:  # If no ice lens, then no water should be able to move as
                 # it should preferentially percolate downwards.
@@ -625,11 +647,13 @@ class TemporaryCell:
         boolean array determining whether the IceShelf is saturated at each vertical point
     """
 
-    def __init__(self, lake_depth, water, saturation, meltflag):
+    def __init__(self, lake_depth, water, saturation, meltflag, lake):
         self.lake_depth = lake_depth
         self.water = water
         self.saturation = saturation
         self.meltflag = meltflag
+        self.lake = lake
+
 
 
 def move_water(
@@ -671,39 +695,41 @@ def move_water(
         This should not occur, so please get in touch with the developers, so we can source and fix the issue.
     """
 
-    water_level_to_sort = np.zeros((max_grid_col, max_grid_row))
 
     # First, we need to determine the water level.
     total_water = 0
     catchment_out_water = 0
-    for col in range(0, max_grid_col):
-        for row in range(0, max_grid_row):
-            cell = grid[col][row]
+    for row in range(0, max_grid_row):
+        for col in range(0, max_grid_col):
+            cell = grid[row][col]
             update_water_level(cell)
-            water_level_to_sort[col, row] = cell.water_level
+            # water_level_to_sort[row, col] = cell.water_level
             total_water += np.sum(cell.water) + cell.lake_depth
 
     # Create temporary cells for our water to move in and out of. This is required so that the water all moves
     # simultaneously.
 
     temp_grid = []
-    for col in range(max_grid_col):
+    for row in range(max_grid_row):
         _l = []
-        for row in range(max_grid_row):
+        for col in range(max_grid_col):
+            # Append *copies* of the arrays to temporary grid, otherwise these will be pointers to the *actual*
+            # cell arrays, making the whole thing pointless.
             _l.append(
                 TemporaryCell(
-                    grid[col][row].lake_depth,
-                    grid[col][row].water,
-                    grid[col][row].saturation,
-                    grid[col][row].meltflag
+                    np.copy(grid[row][col].lake_depth),
+                    np.copy(grid[row][col].water),
+                    np.copy(grid[row][col].saturation),
+                    np.copy(grid[row][col].meltflag),
+                    np.copy(grid[row][col].lake)
                 )
             )
         temp_grid.append(_l)
 
     # Now loop through the cells again, this time actually performing the movement step.
-    for col in range(max_grid_col):
-        for row in range(max_grid_row):
-            cell = grid[col][row]
+    for row in range(max_grid_row):
+        for col in range(max_grid_col):
+            cell = grid[row][col]
 
             if cell.valid_cell and ((cell.ice_lens and (cell.water > 0).any()) or (cell.lake and cell.lake_depth > 0)):
                 # Get the points with the largest difference in heights
@@ -749,13 +775,15 @@ def move_water(
     new_water = 0
     # Loop over our grid, set the values to the corresponding temporary values,
     # i.e. performing our movement in one step
-    for col in range(0, max_grid_col):
-        for row in range(0, max_grid_row):
-            cell = grid[col][row]
-            temporary_cell = temp_grid[col][row]
-            cell.water = temporary_cell.water
-            cell.lake_depth = temporary_cell.lake_depth
-
+    for row in range(0, max_grid_row):
+        for col in range(0, max_grid_col):
+            cell = grid[row][col]
+            temporary_cell = temp_grid[row][col]
+            # Round water and lake depth to 10 decimal places, which gives a bit of robustness to floating-point
+            # errors. This is only ever really an issue in a case with some kind of symmetry, e.g. the
+            # 10x10 Gaussian lakes test case.
+            cell.water = np.around(temporary_cell.water, 10)
+            cell.lake_depth = np.around(temporary_cell.lake_depth, 10)
             cell.saturation = temporary_cell.saturation
             cell.meltflag = temporary_cell.meltflag
             new_water += np.sum(cell.water) + cell.lake_depth
@@ -774,6 +802,9 @@ def move_water(
                         calc_saturation(cell, k, end=True)
 
             update_water_level(cell)
+
+
+
     print("\nLateral water movement diagnostics:")
     print("Starting water total = ", total_water)
     print("Finishing water total = ", new_water)

--- a/src/monarchs/physics/percolation_functions.py
+++ b/src/monarchs/physics/percolation_functions.py
@@ -69,9 +69,9 @@ def percolation(cell, timestep, lateral_refreeze_flag=False, perc_time_toggle=Tr
                     cell.ice_lens = True
                     cell.saturation[v_lev] = True
                     if v_lev < cell.ice_lens_depth:
-                        print(
-                            f"Ice lens formation at v_lev = {v_lev}, column = {cell.column}, row = {cell.row}"
-                        )
+                        #print(
+                        #    f"Ice lens formation at v_lev = {v_lev}, column = {cell.column}, row = {cell.row}"
+                        #)
                         cell.ice_lens_depth = v_lev
 
                     calc_saturation(cell, v_lev)

--- a/src/monarchs/physics/solver.py
+++ b/src/monarchs/physics/solver.py
@@ -69,9 +69,9 @@ def firn_heateqn_solver(x, args, fixed_sfc=False):
         # soldict: OptimizeResult = root(eqn, x, args=args, method='df-sane',
         #                                options={'line_search': 'cheng', 'maxfev': 1000,
         #                                         'ftol': 1e-10})
-        soldict: OptimizeResult = root(eqn, x, args=args, method='hybrd')
-        if np.isnan(soldict.x).any() or np.any(soldict.x > 320) or np.any(soldict.x < 220) or not soldict.success:
-            raise Exception('Bad spectral solver output')
+        soldict: OptimizeResult = root(eqn, x, args=args, method='hybr')
+        # if np.isnan(soldict.x).any() or np.any(soldict.x > 320) or np.any(soldict.x < 220) or not soldict.success:
+        #     raise Exception('Bad spectral solver output')
 
     except Exception as e:
         # print(e)

--- a/tests/serial/test_catchment_outflow.py
+++ b/tests/serial/test_catchment_outflow.py
@@ -9,13 +9,13 @@ def test_catchment_outflow():
     lake_depths = np.array([[0.8, 10, 0.8], [0.8, 5, 0.8]]).T
     firn_depths = np.array([[20, 30, 20], [20, 25, 20]]).T
     grid = []
-    for i in range(len(lake_depths)):
+    for i in range(len(lake_depths.T)):
         _l = []
-        for j in range(2):
+        for j in range(len(lake_depths)):
             _l.append(
                 IceShelf(
-                    firn_depth=firn_depths[i, j],
-                    lake_depth=lake_depths[i, j],
+                    firn_depth=firn_depths[j, i],
+                    lake_depth=lake_depths[j, i],
                     vert_grid=40,
                     vertical_profile=np.linspace(0, 20, 40),
                     saturation=np.zeros(40),

--- a/tests/serial/test_ice_lens_lateral_water.py
+++ b/tests/serial/test_ice_lens_lateral_water.py
@@ -18,23 +18,23 @@ def test_ice_lens():
         ]
     ).T
     grid = []
-    for i in range(len(lake_depths)):
+    for i in range(len(lake_depths.T)):
         _l = []
-        for j in range(2):
+        for j in range(len(lake_depths)):
             _l.append(
                 IceShelf(
-                    firn_depth=firn_depths[i, j],
-                    lake_depth=lake_depths[i, j],
+                    firn_depth=firn_depths[j, i],
+                    lake_depth=lake_depths[j, i],
                     vert_grid=40,
-                    vertical_profile=np.linspace(0, firn_depths[i, j], 40),
-                    saturation=saturation[:, i, j],
+                    vertical_profile=np.linspace(0, firn_depths[j, i], 40),
+                    saturation=saturation[:, j, i],
                     lake=False,
                     lid=False,
-                    ice_lens=ice_lens[i, j],
-                    ice_lens_depth=ice_lens_depths[i, j],
+                    ice_lens=ice_lens[j, i],
+                    ice_lens_depth=ice_lens_depths[j, i],
                     rho_water=1000,
                     rho=np.ones(40) * 500,
-                    Lfrac=np.ones(40) * Lfrac[i, j],
+                    Lfrac=np.ones(40) * Lfrac[j, i],
                     Sfrac=np.ones(40) * 0.5,
                     valid_cell=True,
                     firn_temperature=np.linspace(240, 273.15, 40)[::-1],
@@ -47,6 +47,10 @@ def test_ice_lens():
             )
 
         grid.append(_l)
+    for i in range(len(grid)):
+        for j in range(len(grid[i])):
+            grid[i][j].rho_ice = 917
+
 
     print(get_2d_grid(grid, "Lfrac"))
     move_water(
@@ -80,23 +84,23 @@ def test_ice_lens():
         ]
     ).T
     grid = []
-    for i in range(len(lake_depths)):
+    for i in range(len(lake_depths.T)):
         _l = []
-        for j in range(2):
+        for j in range(len(lake_depths)):
             _l.append(
                 IceShelf(
-                    firn_depth=firn_depths[i, j],
-                    lake_depth=lake_depths[i, j],
+                    firn_depth=firn_depths[j, i],
+                    lake_depth=lake_depths[j, i],
                     vert_grid=40,
-                    vertical_profile=np.linspace(0, firn_depths[i, j], 40),
-                    saturation=saturation[:, i, j],
+                    vertical_profile=np.linspace(0, firn_depths[j, i], 40),
+                    saturation=saturation[:, j, i],
                     lake=False,
                     lid=False,
-                    ice_lens=ice_lens[i, j],
-                    ice_lens_depth=ice_lens_depths[i, j],
+                    ice_lens=ice_lens[j, i],
+                    ice_lens_depth=ice_lens_depths[j, i],
                     rho_water=1000,
                     rho=np.ones(40) * 500,
-                    Lfrac=np.ones(40) * Lfrac[i, j],
+                    Lfrac=np.ones(40) * Lfrac[j, i],
                     Sfrac=np.ones(40) * 0.5,
                     valid_cell=True,
                     firn_temperature=np.linspace(240, 273.15, 40)[::-1],
@@ -109,6 +113,11 @@ def test_ice_lens():
             )
 
         grid.append(_l)
+
+    for i in range(len(grid)):
+        for j in range(len(grid[i])):
+            grid[i][j].rho_ice = 917
+
 
     print(get_2d_grid(grid, "Lfrac"))
     move_water(


### PR DESCRIPTION
This PR was motivated by some curious results when running the 10x10 Gaussian lakes test case - we were getting asymmetric results - rather than getting a line of symmetry in `x = y`. This ended up being a multifaceted problem (which took an entire weekend to diagnose!), with the following issues:

1) the Gaussian DEM was not entirely symmetric, due to the way it was being interpolated. This has been fixed by a) generating the DEM on a coarser grid, and b) taking the mean value reflected in its axis of symmetry. The use of a coarser grid also highlights the corner lakes better, such that these now meaningfully impact the simulation.

2) The lateral movement of water itself was asymmetric. The implication was that this then had something to do with the order in which the movement occurred. The issue was how the temporary grid used to store intermediate values was set up - rather than using a copy of the original arrays, these were instead being passed a pointer. 

This wouldn't have been a problem, but for the `saturation` flag being set during the movement. Movement in one direction was setting the saturation flag to `0` for other directions, causing the water to be deposited in different vertical positions on the ice shelf - this made it hard to debug as the issue was with the vertically-dependent values rather than column-integrated ones, so it wasn't picked up by e.g. conservation of mass checks, and the impacts weren't seen until the following timestep (the firn columns evolve differently based on this). 

Using `np.copy` on the arrays used to set up the temporary grid fixes this issue.

3) Floating-point errors during this process change the results also. Given the symmetry of the case, and the choice of lateral flow algorithm, a tiny rounding error can cause an asymmetry to form as water is moved to/from a different place. This was *really* hard to diagnose, and I'm still not sure *exactly* why it occurs (it seems reproducible).

The fix is to instead round the final water and lake depths to 10 decimal places once the movement has occurred. This seems to be a robust workaround to the issue, and I don't think should trigger a water conservation error (at worst we are getting `1E-6` units of water added for a 100x100 case, which seems fine). Realistically, this shouldn't be a problem for real-world cases with DEM inputs.

In the process of doing these fixes, I have also converted the indexing from `[col][row]` to [row][col]`, as this is how Python actually indexes arrays and it was misleading beforehand. This includes the corresponding changes to the directions in the lateral movement functions. This PR also contains a few other little bugfixes and documentation additions, and a barebones script for generating animated gifs out of model output.



